### PR TITLE
Ensure chart is updated when fail count is 0

### DIFF
--- a/e2e-test-runner/index.js
+++ b/e2e-test-runner/index.js
@@ -31,8 +31,9 @@ function runTests() {
 
   let runner = mocha.run((failCount)=>{
     stackDriver.createTimeSeriesEntry("e2eruns/passcount", runner.total - failCount);
+    stackDriver.createTimeSeriesEntry("e2eruns/failcount", failCount);
+
     if (failCount) {
-      stackDriver.createTimeSeriesEntry("e2eruns/failcount", failCount);
       restartTesting(hibernateTimeMS)
     }
   });


### PR DESCRIPTION
The stackdriver chart maintains the last entry so after a failure where
failcount may be 1 or 2 we have to push another entry indicating fail
count of 0.
@fjvallarino  Please review