### PR TITLE
Ensure spark exists before calling write

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -31,28 +31,28 @@ function registerIPC() {
       console.error(`Worker received ${JSON.stringify(message)} for an id it does not handle`);
     }
     else if (message.msg === "presence-result") {
-      sparksById[message.clientId].write(message);
+      sparksById[message.clientId] && sparksById[message.clientId].write(message);
     }
     else if (message.msg === "content-update") {
       stats.incrementCount("intervalMessageCount");
-      sparksById[message.displayId].write(message);
+      sparksById[message.displayId] && sparksById[message.displayId].write(message);
     }
     else if (message.msg === "screenshot-request") {
       stats.incrementCount("intervalMessageCount");
-      sparksById[message.displayId].write(message);
+      sparksById[message.displayId] && sparksById[message.displayId].write(message);
     }
     else if (message.msg === "screenshot-saved" || message.msg === "screenshot-failed") {
       stats.incrementCount("intervalMessageCount");
-      sparksById[message.clientId].write(message);
+      sparksById[message.clientId] && sparksById[message.clientId].write(message);
     }
     else if (message.msg === "restart-request" || message.msg === "reboot-request") {
       stats.incrementCount("intervalMessageCount");
-      sparksById[message.displayId].write(message);
+      sparksById[message.displayId] && sparksById[message.displayId].write(message);
     }
     else if (message.msg === "duplicate-display-id") {
       stats.incrementCount("intervalMessageCount");
 
-      sparksById[message.displayId].write(message);
+      sparksById[message.displayId] && sparksById[message.displayId].write(message);
 
       delete displaysBySpark[sparksById[message.displayId].id];
       delete sparksById[message.displayId];


### PR DESCRIPTION
@fjvallarino this is to prevent a lot of worked deaths that are showing up in the logs 

```
Feb 14 14:40:39 instance-group-messaging-service-588r server.js[26957]: sparksById[message.clientId].write(message);
Feb 14 14:40:39 instance-group-messaging-service-588r server.js[26957]: ^
Feb 14 14:40:39 instance-group-messaging-service-588r server.js[26957]: TypeError: Cannot read property 'write' of undefined
Feb 14 14:40:39 instance-group-messaging-service-588r server.js[26957]: at process.on (/home/jenkins/display-messaging-service/worker.js:34:35)
Feb 14 14:40:39 instance-group-messaging-service-588r server.js[26957]: at emitTwo (events.js:111:20)
Feb 14 14:40:39 instance-group-messaging-service-588r server.js[26957]: at process.emit (events.js:191:7)
Feb 14 14:40:39 instance-group-messaging-service-588r server.js[26957]: at process.nextTick (internal/child_process.js:719:12)
Feb 14 14:40:39 instance-group-messaging-service-588r server.js[26957]: at _combinedTickCallback (internal/process/next_tick.js:67:7)
Feb 14 14:40:39 instance-group-messaging-service-588r server.js[26957]: at process._tickCallback (internal/process/next_tick.js:98:9)
Feb 14 14:40:39 instance-group-messaging-service-588r server.js[26957]: Worker 24883 died with code: 1, and signal: null
Feb 14 14:40:40 instance-group-messaging-service-588r server.js[26957]: Starting a new worker 1278
Feb 14 14:40:40 instance-group-messaging-service-588r server.js[26957]: Worker 1278 is online

```